### PR TITLE
Allocate shared stack space as needed, close #3

### DIFF
--- a/include/cocpp/core/co_env.h
+++ b/include/cocpp/core/co_env.h
@@ -61,6 +61,8 @@ private:                                                                        
     std::future<void>                                                               worker__;                             // 工作线程
     co_sleep_controller                                                             sleep_controller__;                   // 睡眠控制器
     co_stack*                                                                       shared_stack__ { nullptr };           // 共享栈
+    size_t                                                                          shared_stack_size__ { 0 };            // 共享栈大小
+    std::once_flag                                                                  shared_stack_once_flag__;             // 共享栈初始化标志
     co_ctx* const                                                                   idle_ctx__ { nullptr };               // 空闲协程
     co_tid                                                                          schedule_thread_tid__ {};             // 调度线程tid
     std::vector<std::list<co_ctx*>>                                                 all_normal_ctx__ { CO_MAX_PRIORITY }; // 所有普通协程
@@ -71,23 +73,24 @@ private:                                                                        
     mutable std::recursive_mutex                                                    mu_min_priority__;                    // 最小优先级锁
     std::recursive_mutex                                                            schedule_lock__;                      // 调度锁
 
-    co_env(co_stack* shared_stack, co_ctx* idle_ctx, bool create_new_thread); // 构造函数
-    void               start_schedule_routine__();                            // 启动调度线程
-    void               remove_detached_ctx__();                               // 删除已经detach的ctx
-    void               remove_all_ctx__();                                    // 删除所有ctx
-    co_ctx*            next_ctx__();                                          // 下一个ctx
-    void               save_shared_stack__(co_ctx* ctx);                      // 保存共享栈
-    void               restore_shared_stack__(co_ctx* ctx);                   // 恢复共享栈
-    void               switch_shared_stack_ctx__();                           // 切换共享栈上的ctx
-    void               switch_normal_ctx__();                                 // 切换普通ctx
-    bool               need_sleep__();                                        // 是否需要睡眠
-    co_ctx*            choose_ctx_from_normal_list__();                       // 从普通协程列表中选择ctx
-    std::list<co_ctx*> all_ctx__();                                           // 所有ctx
-    std::list<co_ctx*> all_scheduleable_ctx__() const;                        // 所有可调度ctx
-    bool               can_schedule__() const;                                // 是否可以调度
-    void               update_min_priority__(int priority);                   // 更新最小优先级
-    static size_t      get_valid_stack_size__(co_ctx* ctx);                   // 获取有效栈大小
-    static void        update_ctx_state__(co_ctx* curr, co_ctx* next);        // 更新ctx状态
+    co_env(size_t shared_stack_size, co_ctx* idle_ctx, bool create_new_thread); // 构造函数
+    void               start_schedule_routine__();                              // 启动调度线程
+    void               remove_detached_ctx__();                                 // 删除已经detach的ctx
+    void               remove_all_ctx__();                                      // 删除所有ctx
+    co_ctx*            next_ctx__();                                            // 下一个ctx
+    void               save_shared_stack__(co_ctx* ctx);                        // 保存共享栈
+    void               restore_shared_stack__(co_ctx* ctx);                     // 恢复共享栈
+    void               switch_shared_stack_ctx__();                             // 切换共享栈上的ctx
+    void               switch_normal_ctx__();                                   // 切换普通ctx
+    bool               need_sleep__();                                          // 是否需要睡眠
+    co_ctx*            choose_ctx_from_normal_list__();                         // 从普通协程列表中选择ctx
+    std::list<co_ctx*> all_ctx__();                                             // 所有ctx
+    std::list<co_ctx*> all_scheduleable_ctx__() const;                          // 所有可调度ctx
+    bool               can_schedule__() const;                                  // 是否可以调度
+    void               update_min_priority__(int priority);                     // 更新最小优先级
+    void               create_shared_stack__();                                 // 创建共享栈
+    static size_t      get_valid_stack_size__(co_ctx* ctx);                     // 获取有效栈大小
+    static void        update_ctx_state__(co_ctx* curr, co_ctx* next);          // 更新ctx状态
     struct
     {                                  //
         co_ctx* from { nullptr };      // 从哪个ctx切换

--- a/include/cocpp/core/co_vos.h
+++ b/include/cocpp/core/co_vos.h
@@ -10,7 +10,7 @@ class co_stack;
 class co_env;
 
 void     switch_to(co_byte** curr_regs, co_byte** next_regs); // 切换上下文
-void     init_ctx(co_stack* shared_stack, co_ctx* ctx);       // 初始化ctx
+void     init_ctx(co_ctx* ctx);                               // 初始化ctx
 co_byte* get_rsp(co_ctx* ctx);                                // 获取ctx的rsp
 co_tid   gettid();                                            // 获取当前线程id
 void     setup_switch_handler();                              // 设置切换上下文的处理函数

--- a/include/cocpp/core/co_vos.h
+++ b/include/cocpp/core/co_vos.h
@@ -10,7 +10,7 @@ class co_stack;
 class co_env;
 
 void     switch_to(co_byte** curr_regs, co_byte** next_regs); // 切换上下文
-void     init_ctx(co_ctx* ctx);                               // 初始化ctx
+void     init_ctx(co_stack* shared_stack, co_ctx* ctx);       // 初始化ctx
 co_byte* get_rsp(co_ctx* ctx);                                // 获取ctx的rsp
 co_tid   gettid();                                            // 获取当前线程id
 void     setup_switch_handler();                              // 设置切换上下文的处理函数

--- a/include/cocpp/core/co_vos.h
+++ b/include/cocpp/core/co_vos.h
@@ -10,7 +10,7 @@ class co_stack;
 class co_env;
 
 void     switch_to(co_byte** curr_regs, co_byte** next_regs); // 切换上下文
-void     init_ctx(co_stack* shared_stack, co_ctx* ctx);       // 初始化ctx
+void     init_ctx(co_stack* stack, co_ctx* ctx);              // 初始化ctx
 co_byte* get_rsp(co_ctx* ctx);                                // 获取ctx的rsp
 co_tid   gettid();                                            // 获取当前线程id
 void     setup_switch_handler();                              // 设置切换上下文的处理函数

--- a/source/cocpp/core/co_env.cpp
+++ b/source/cocpp/core/co_env.cpp
@@ -56,10 +56,9 @@ void co_env::add_ctx(co_ctx* ctx)
     if (ctx->test_flag(CO_CTX_FLAG_SHARED_STACK))
     {
         std::call_once(shared_stack_once_flag__, [this] { create_shared_stack__(); });
-        ctx->set_stack(shared_stack__);
     }
 
-    init_ctx(ctx); // 初始化ctx
+    init_ctx(shared_stack__, ctx); // 初始化ctx
     ctx_initted().pub(ctx);
 
     move_ctx_to_here(ctx);

--- a/source/cocpp/core/co_env.cpp
+++ b/source/cocpp/core/co_env.cpp
@@ -19,12 +19,13 @@ CO_NAMESPACE_BEGIN
 
 thread_local co_env* current_env__ = nullptr;
 
-co_env::co_env(co_stack* shared_stack, co_ctx* idle_ctx, bool create_new_thread)
+co_env::co_env(size_t shared_stack_size, co_ctx* idle_ctx, bool create_new_thread)
     : sleep_controller__([this] { return need_sleep__(); })
-    , shared_stack__(shared_stack)
+    , shared_stack_size__(shared_stack_size)
     , idle_ctx__(idle_ctx)
 {
     idle_ctx__->set_env(this);
+    create_shared_stack__();
     if (create_new_thread)
     {
         // 此处设置状态是防止 add_ctx 前调度线程还未准备好，状态断言失败
@@ -39,6 +40,11 @@ co_env::co_env(co_stack* shared_stack, co_ctx* idle_ctx, bool create_new_thread)
     }
 }
 
+void co_env::create_shared_stack__()
+{
+    shared_stack__ = co_stack_factory::instance()->create_stack(shared_stack_size__);
+}
+
 void co_env::add_ctx(co_ctx* ctx)
 {
     assert(ctx != nullptr);
@@ -46,7 +52,14 @@ void co_env::add_ctx(co_ctx* ctx)
     {
         throw co_error("env state error");
     }
-    init_ctx(shared_stack__, ctx); // 初始化ctx
+
+    if (ctx->test_flag(CO_CTX_FLAG_SHARED_STACK))
+    {
+        std::call_once(shared_stack_once_flag__, [this] { create_shared_stack__(); });
+        ctx->set_stack(shared_stack__);
+    }
+
+    init_ctx(ctx); // 初始化ctx
     ctx_initted().pub(ctx);
 
     move_ctx_to_here(ctx);

--- a/source/cocpp/core/co_env_factory.cpp
+++ b/source/cocpp/core/co_env_factory.cpp
@@ -9,9 +9,8 @@ CO_NAMESPACE_BEGIN
 
 co_env* co_env_factory::create_env(size_t stack_size)
 {
-    auto idle_ctx     = create_idle_ctx__();
-    auto shared_stack = stack_factory__->create_stack(stack_size);
-    auto ret          = env_pool__.create_obj(shared_stack, idle_ctx, true);
+    auto idle_ctx = create_idle_ctx__();
+    auto ret      = env_pool__.create_obj(stack_size, idle_ctx, true);
     assert(ret != nullptr);
     idle_ctx->set_state(co_state::running);
     return ret;
@@ -30,14 +29,16 @@ void co_env_factory::destroy_env(co_env* env)
     auto shared_stack = env->shared_stack__;
     env_pool__.destroy_obj(env);
     co_ctx_factory::instance()->destroy_ctx(idle_ctx);
-    stack_factory__->destroy_stack(shared_stack);
+    if (shared_stack != nullptr)
+    {
+        stack_factory__->destroy_stack(shared_stack);
+    }
 }
 
 co_env* co_env_factory::create_env_from_this_thread(size_t stack_size)
 {
-    auto idle_ctx     = create_idle_ctx__();
-    auto shared_stack = stack_factory__->create_stack(stack_size);
-    auto ret          = env_pool__.create_obj(shared_stack, idle_ctx, false);
+    auto idle_ctx = create_idle_ctx__();
+    auto ret      = env_pool__.create_obj(stack_size, idle_ctx, false);
     idle_ctx->set_state(co_state::running);
     return ret;
 }

--- a/source/cocpp/core/co_vos_gcc_x86_64.cpp
+++ b/source/cocpp/core/co_vos_gcc_x86_64.cpp
@@ -122,10 +122,14 @@ void switch_to(co_byte** curr, co_byte** next)
                        : "memory");
 }
 
-void init_ctx(co_ctx* ctx)
+void init_ctx(co_stack* shared_stack, co_ctx* ctx)
 {
     auto      context = get_sigcontext_64(ctx);
     co_stack* stack   = ctx->stack();
+    if (ctx->test_flag(CO_CTX_FLAG_SHARED_STACK))
+    {
+        stack = shared_stack;
+    }
 
     auto config = ctx->config();
 

--- a/source/cocpp/core/co_vos_gcc_x86_64.cpp
+++ b/source/cocpp/core/co_vos_gcc_x86_64.cpp
@@ -122,14 +122,11 @@ void switch_to(co_byte** curr, co_byte** next)
                        : "memory");
 }
 
-void init_ctx(co_stack* shared_stack, co_ctx* ctx)
+void init_ctx(co_ctx* ctx)
 {
     auto      context = get_sigcontext_64(ctx);
     co_stack* stack   = ctx->stack();
-    if (ctx->test_flag(CO_CTX_FLAG_SHARED_STACK))
-    {
-        stack = shared_stack;
-    }
+
     auto config = ctx->config();
 
     CO_SETREG(context, sp, stack->stack_top());

--- a/source/cocpp/core/co_vos_gcc_x86_64.cpp
+++ b/source/cocpp/core/co_vos_gcc_x86_64.cpp
@@ -122,17 +122,9 @@ void switch_to(co_byte** curr, co_byte** next)
                        : "memory");
 }
 
-void init_ctx(co_stack* shared_stack, co_ctx* ctx)
+void init_ctx(co_stack* stack, co_ctx* ctx)
 {
-    auto      context = get_sigcontext_64(ctx);
-    co_stack* stack   = ctx->stack();
-    if (ctx->test_flag(CO_CTX_FLAG_SHARED_STACK))
-    {
-        stack = shared_stack;
-    }
-
-    auto config = ctx->config();
-
+    auto context = get_sigcontext_64(ctx);
     CO_SETREG(context, sp, stack->stack_top());
     CO_SETREG(context, bp, stack->stack_top());
     CO_SETREG(context, ip, &co_ctx::real_entry);

--- a/test/other.cpp
+++ b/test/other.cpp
@@ -30,19 +30,19 @@ using namespace std::chrono_literals;
 
 TEST(stl, vector)
 {
-    std::vector<std::string> v1;
-    std::vector<std::string> v2;
+    std::vector<int> v1;
+    std::vector<int> v2;
     co                       c1([&] {
         for (auto i = 0; i < 10000; ++i)
         {
-            v1.push_back(std::to_string(i));
+            v1.push_back(i);
             this_co::yield();
         }
     });
     co                       c2([&] {
         for (auto i = 0; i < 10000; ++i)
         {
-            v2.push_back(std::to_string(i));
+            v2.push_back(i);
             this_co::yield();
         }
     });


### PR DESCRIPTION
Because shared stack space is not used most of the time, its memory allocation is adjusted to on-demand allocation. The shared stack space is allocated when a new shared stack CTX is added